### PR TITLE
Fixed: request is rejected when NSM is not connected

### DIFF
--- a/Administrator/src/ssw_pers_admin_service.c
+++ b/Administrator/src/ssw_pers_admin_service.c
@@ -480,15 +480,6 @@ static bool_t persadmin_ProcessRequest(persadmin_request_msg_s* psRequest, long*
     bool_t    bLockedMtx        = false;
     long result             = -1 ;
 
-    /* check if PAS is registered to NSM */
-    if(false == persadmin_IsRegisteredToNSM())
-    {
-        DLT_LOG(persAdminSvcDLTCtx, DLT_LOG_WARN, DLT_STRING("Cannot process request. Not registered to NSM yet..."));
-
-        bEverythingOK = false;
-    }
-
-
     /* check if a shutdown is in progress */
     if(true == bEverythingOK)
     {


### PR DESCRIPTION
The issue is observed on system start-up. When pas-daemon is started it will notify with sd_notify, but actually it will be not able to process any request until NSM will be connected due to this check.

Cons:
1. pas-daemon will not work without NSM. But NSM should not be the strict dependency.
2. There is no easy way to know is pas-daemon actually able to process requests, because sd_notify in case of systemd is happened before NSM is connected