### PR TITLE
Make snprintf comply with -Werror=format-security

### DIFF
--- a/Administrator/src/ssw_pers_admin_common.c
+++ b/Administrator/src/ssw_pers_admin_common.c
@@ -595,7 +595,7 @@ sint_t persadmin_compress(pstr_t compressTo, pstr_t compressFrom)
     }
 
     memset(pchParentPath, 0, sizeof(pchParentPath));
-    snprintf(pchParentPath, sizeof(pchParentPath), compressFrom);
+    snprintf(pchParentPath, sizeof(pchParentPath), "%s", compressFrom);
     pchStrPos = strrchr(pchParentPath, '/');
     if(NIL != pchStrPos)
     {

--- a/test/pers_svc_test/src/test_pas_import_source_content.c
+++ b/test/pers_svc_test/src/test_pas_import_source_content.c
@@ -778,7 +778,7 @@ static sint_t persadmin_compress(pstr_t compressTo, pstr_t compressFrom)
     }
 
     memset(pchParentPath, 0, sizeof(pchParentPath));
-    snprintf(pchParentPath, sizeof(pchParentPath), compressFrom);
+    snprintf(pchParentPath, sizeof(pchParentPath), "%s", compressFrom);
     pchStrPos = strrchr(pchParentPath, '/');
     if(NIL != pchStrPos)
     {

--- a/test/pers_svc_test/src/test_pas_recovery_backup_content.c
+++ b/test/pers_svc_test/src/test_pas_recovery_backup_content.c
@@ -775,7 +775,7 @@ static sint_t persadmin_compress(pstr_t compressTo, pstr_t compressFrom)
     }
 
     memset(pchParentPath, 0, sizeof(pchParentPath));
-    snprintf(pchParentPath, sizeof(pchParentPath), compressFrom);
+    snprintf(pchParentPath, sizeof(pchParentPath), "%s", compressFrom);
     pchStrPos = strrchr(pchParentPath, '/');
     if(NIL != pchStrPos)
     {


### PR DESCRIPTION
Fixes the following error when bulding with GCC 8.2 and
-Werror=format-security:

  error: format not a string literal and no format arguments
  [-Werror=format-security]

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>