### PR TITLE
Replace unknown oip-cpi-mandatory.target in systemd service file

### DIFF
--- a/Administrator/config/pas-daemon.service.in
+++ b/Administrator/config/pas-daemon.service.in
@@ -16,4 +16,4 @@ StartLimitBurst=3
 StartLimitAction=reboot
 
 [Install]
-WantedBy=oip-cpi-mandatory.target
+WantedBy=multi-user.target


### PR DESCRIPTION
With a well known systemd target. oip-cpi-mandatory.target is Continental specific?

Do not know for sure that multi-user.target is the best one. Perhaps the administrator service should be changed to be D-Bus activated in the future since it is not required to be running all the time (if I have understood things correctly).